### PR TITLE
Adds functionality to only show tagged sounds

### DIFF
--- a/src/main/java/com/visualsounds/GameSoundList.java
+++ b/src/main/java/com/visualsounds/GameSoundList.java
@@ -13,7 +13,7 @@ public class GameSoundList {
     public void add(GameSound gameSound) {
         this.gameSoundList.add(0, gameSound);
         if (this.gameSoundList.size() > maxLength) {
-            this.gameSoundList = this.gameSoundList.subList(0, maxLength);
+            this.gameSoundList = new ArrayList<>(gameSoundList.subList(0, maxLength));
         }
     }
 

--- a/src/main/java/com/visualsounds/VisualSoundsConfig.java
+++ b/src/main/java/com/visualsounds/VisualSoundsConfig.java
@@ -112,4 +112,14 @@ public interface VisualSoundsConfig extends Config {
     default String ignoredSounds() {
         return "";
     }
+
+    @ConfigItem(
+            keyName = "showOnlyTagged",
+            name = "Show Only Tagged Sounds",
+            description = "Show only the sounds that are recolored.",
+            position = 10
+    )
+    default boolean showOnlyTagged() {
+        return false;
+    }
 }

--- a/src/main/java/com/visualsounds/VisualSoundsPlugin.java
+++ b/src/main/java/com/visualsounds/VisualSoundsPlugin.java
@@ -46,6 +46,7 @@ public class VisualSoundsPlugin extends Plugin {
 
     private boolean displaySoundEffects = true;
     private boolean displayAreaEffects = false;
+    private boolean showOnlyTagged = false;
 
     @Override
     protected void startUp() throws Exception {
@@ -79,6 +80,7 @@ public class VisualSoundsPlugin extends Plugin {
 
         displaySoundEffects = config.displaySoundEffects();
         displayAreaEffects = config.displayAreaSounds();
+        showOnlyTagged = config.showOnlyTagged();
     }
 
     @Subscribe
@@ -103,6 +105,8 @@ public class VisualSoundsPlugin extends Plugin {
      */
     private void handleSoundEffect(int soundId) {
         if (ignoredSounds.contains(soundId))
+            return;
+        if (showOnlyTagged && !soundColors.containsKey(soundId))
             return;
 
         Color soundColor = soundColors.getOrDefault(soundId, Color.white);


### PR DESCRIPTION
Description:

Adds the functionality to only show the sounds that are tagged resolving #5, as well as fixes a memory leakage bug addressed in #4.

Notes:

I have a friend who's hard of hearing, so this plugin is a lifesaver to him. Thanks for your work!