### PR TITLE
Change config group from `example` to `visualsounds`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.13.1'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/visualsounds/VisualSoundsConfig.java
+++ b/src/main/java/com/visualsounds/VisualSoundsConfig.java
@@ -7,7 +7,7 @@ import net.runelite.client.config.Range;
 
 import java.awt.*;
 
-@ConfigGroup("example")
+@ConfigGroup("visualsounds")
 public interface VisualSoundsConfig extends Config {
     @ConfigItem(
             keyName = "displaySoundEffects",

--- a/src/main/java/com/visualsounds/VisualSoundsPlugin.java
+++ b/src/main/java/com/visualsounds/VisualSoundsPlugin.java
@@ -40,6 +40,12 @@ public class VisualSoundsPlugin extends Plugin {
     @Inject
     private OverlayManager overlayManager;
 
+    @Inject
+    private ConfigManager configManager;
+
+    private static final String OLD_CONFIG_GROUP = "example";
+    private static final String CONFIG_GROUP = "visualsounds";
+
     private HashMap<Integer, Color> soundColors = new HashMap<>();
 
     private Set<Integer> ignoredSounds = new HashSet<>();
@@ -51,6 +57,7 @@ public class VisualSoundsPlugin extends Plugin {
     @Override
     protected void startUp() throws Exception {
         log.info("Visual sounds started!");
+        this.migrateOldConfigItems();
         this.overlayManager.add(overlay);
         this.reload();
     }
@@ -64,6 +71,31 @@ public class VisualSoundsPlugin extends Plugin {
     protected void shutDown() throws Exception {
         log.info("Visual sounds stopped!");
         this.overlayManager.remove(overlay);
+    }
+
+    private <T> void migrateOldConfigItem(String key, Class<T> clazz) {
+        T old = this.configManager.getConfiguration(OLD_CONFIG_GROUP, key, clazz);
+        if (old != null) {
+            log.debug("Importing config item {}: {}", key, old);
+            this.configManager.setConfiguration(CONFIG_GROUP, key, old);
+            this.configManager.unsetConfiguration(OLD_CONFIG_GROUP, key);
+        }
+    }
+
+    private void migrateOldConfigItems() {
+        this.migrateOldConfigItem("displaySoundEffects", Boolean.TYPE);
+        this.migrateOldConfigItem("displayAreaSounds", Boolean.TYPE);
+        this.migrateOldConfigItem("soundCountLimit", Integer.TYPE);
+
+        this.migrateOldConfigItem("category1SoundColor", Color.class);
+        this.migrateOldConfigItem("taggedSoundsCat1", String.class);
+        this.migrateOldConfigItem("category2SoundColor", Color.class);
+        this.migrateOldConfigItem("taggedSoundsCat2", String.class);
+        this.migrateOldConfigItem("category3SoundColor", Color.class);
+        this.migrateOldConfigItem("taggedSoundsCat3", String.class);
+
+        this.migrateOldConfigItem("ignoredSounds", String.class);
+        this.migrateOldConfigItem("showOnlyTagged", Boolean.TYPE);
     }
 
     /**


### PR DESCRIPTION
This PR changes the config group from `example` to `visualsounds`. As a consequence of that, the plugin would lose the config values that users have set.
To resolve that, I have added [this commit](https://github.com/Box-Of-Hats/runelite-plugin-visual-sounds/pull/9/commits/4565a350e4d3950a8ee1823d55ebaac51b5df607) to migrate config values over from the old `example` config group.

# How was this tested
1. Start normal runelite
2. Change all config values in the plugin config menu
3. Close runelite
4. Start this PR's runelite in debug mode
5. Observe config items being migrated by looking at the log.debug values
6. Validate that your config values look the same as they did before in the plugin config menu

I also started runelite with this PR one more time to make sure the migration debug logs didn't show up again, thus verifying that the deletion of the old config worked as expected.

Fixes #8
