### PR TITLE
Added the ability for users to customize visual sound labels.

### DIFF
--- a/src/main/java/com/visualsounds/VisualSoundsConfig.java
+++ b/src/main/java/com/visualsounds/VisualSoundsConfig.java
@@ -116,7 +116,7 @@ public interface VisualSoundsConfig extends Config {
     @ConfigItem(
             keyName = "showOnlyTagged",
             name = "Show Only Tagged Sounds",
-            description = "Show only the sounds that are recolored.",
+            description = "Show only the sounds that are recoloured.",
             position = 10
     )
     default boolean showOnlyTagged() {
@@ -133,4 +133,13 @@ public interface VisualSoundsConfig extends Config {
         return true;
     }
 
+    @ConfigItem(
+            keyName = "customSoundLabels",
+            name = "Custom Sound Labels",
+            description = "A list of custom sound labels. Format: soundId:label, separated by a new line (e.g. 369:Cow attacks)",
+            position = 12
+    )
+    default String customSoundLabels() {
+        return "";
+    }
 }


### PR DESCRIPTION
Added the ability to customize the output text for sound events in the Visual Sounds plugin. For example, users can change human_hit_3 to a more user-friendly message like "Damage Received!".

This is done in the plugin on the side panel with input such as 
[SoundID]:[CustomLabel1]
[SoundID]:[CustomLabel2]

This feature would improve the plugin’s legibility and allow users to personalize the text output to better suit their preferences or enhance readability.