### PR TITLE
Ambient Sounds grouping

### DIFF
--- a/src/main/java/com/visualsounds/AmbientSoundsOverlay.java
+++ b/src/main/java/com/visualsounds/AmbientSoundsOverlay.java
@@ -1,5 +1,6 @@
 package com.visualsounds;
 
+import java.util.HashMap;
 import net.runelite.client.ui.overlay.OverlayLayer;
 import net.runelite.client.ui.overlay.OverlayPanel;
 import net.runelite.client.ui.overlay.OverlayPosition;
@@ -33,7 +34,6 @@ public class AmbientSoundsOverlay extends OverlayPanel {
         List<LayoutableRenderableEntity> renderableEntities = panelComponent.getChildren();
         renderableEntities.clear();
 
-        Iterable<GameSound> gameSoundList = this.plugin.ambientSounds.getGameSounds();
 
         if (displayHeader) {
             renderableEntities.add(
@@ -52,13 +52,22 @@ public class AmbientSoundsOverlay extends OverlayPanel {
             return super.render(graphics2D);
         }
 
+		HashMap<GameSound, GameSoundList> sounds = this.plugin.ambientSounds;
+		for (GameSound key : sounds.keySet()) {
+			renderableEntities.add(
+				LineComponent.builder()
+					.leftColor(key.color).left(key.label)
+					.build());
 
-        for (GameSound gs : gameSoundList) {
-            renderableEntities.add(
-                    LineComponent.builder()
-                            .leftColor(gs.color).left(gs.label)
-                            .build());
-        }
+			// these are sub ambient sounds
+			Iterable<GameSound> gameSoundList = sounds.get(key).getGameSounds();
+			for (GameSound gs : gameSoundList) {
+				renderableEntities.add(
+					LineComponent.builder()
+						.leftColor(gs.color).right(gs.label)
+						.build());
+			}
+		}
 
         return super.render(graphics2D);
     }

--- a/src/main/java/com/visualsounds/GameSound.java
+++ b/src/main/java/com/visualsounds/GameSound.java
@@ -13,4 +13,16 @@ public class GameSound {
         this.label = Integer.toString(soundId);
     }
 
+	@Override
+	public boolean equals(Object obj) {
+		if (!(obj instanceof GameSound))
+			return false;
+		if (obj == this)
+			return true;
+
+		GameSound rhs = (GameSound) obj;
+		return rhs.soundId == this.soundId
+			&& rhs.color == this.color
+			&& rhs.label.equals(this.label);
+	}
 }

--- a/src/main/java/com/visualsounds/VisualSoundsPlugin.java
+++ b/src/main/java/com/visualsounds/VisualSoundsPlugin.java
@@ -4,8 +4,10 @@ import com.google.inject.Provides;
 import lombok.extern.slf4j.Slf4j;
 import net.runelite.api.AmbientSoundEffect;
 import net.runelite.api.Client;
+import net.runelite.api.GameState;
 import net.runelite.api.coords.WorldPoint;
 import net.runelite.api.events.AreaSoundEffectPlayed;
+import net.runelite.api.events.GameStateChanged;
 import net.runelite.api.events.GameTick;
 import net.runelite.api.events.SoundEffectPlayed;
 import net.runelite.api.gameval.VarbitID;
@@ -42,7 +44,7 @@ public class VisualSoundsPlugin extends Plugin {
     private VisualSoundsConfig config;
 
     public final GameSoundList gameSoundList = new GameSoundList(15, false);
-    public final GameSoundList ambientSounds = new GameSoundList(30, true);
+	public final HashMap<GameSound, GameSoundList> ambientSounds = new HashMap<>();
 
     /**
      * Is the plugin currently disabled due to the player being in a blocked area?
@@ -175,6 +177,15 @@ public class VisualSoundsPlugin extends Plugin {
         } else {
             this.overlayManager.remove(visualSoundsOverlay);
         }
+
+		clientThread.invoke(() ->
+		{
+			// Reload the scene to reapply ambient sounds
+			if (client.getGameState() == GameState.LOGGED_IN)
+			{
+				client.setGameState(GameState.LOADING);
+			}
+		});
     }
 
     private static Set<Integer> getNumbersFromConfig(String source) {
@@ -203,18 +214,27 @@ public class VisualSoundsPlugin extends Plugin {
     @Subscribe
     public void onGameTick(GameTick event) {
         this.regionId = WorldPoint.fromLocalInstance(client, client.getLocalPlayer().getLocalLocation()).getRegionID();
-
-        // Ambient sound effects don't play in the same manner as other sounds. Handle them every tick
-        if (displayAmbientEffects) {
-            this.ambientSounds.clear();
-            for (AmbientSoundEffect ambientSoundEffect : client.getAmbientSoundEffects()) {
-                handleAmbientSoundEffect(ambientSoundEffect);
-            }
-        }
-
     }
 
-    @Subscribe
+	@Subscribe(priority = -3)
+	public void onGameStateChanged(GameStateChanged gameStateChanged)
+	{
+		GameState gameState = gameStateChanged.getGameState();
+
+		// on map load ambient sounds
+		if (gameState == GameState.LOGGED_IN)
+		{
+			if (displayAmbientEffects) {
+				this.ambientSounds.clear();
+				for (AmbientSoundEffect ambientSoundEffect : client.getAmbientSoundEffects()) {
+					handleAmbientSoundEffect(ambientSoundEffect);
+				}
+			}
+		}
+	}
+
+
+	@Subscribe(priority = -3)
     public void onSoundEffectPlayed(SoundEffectPlayed soundEffectPlayed) {
         if (!displaySoundEffects) {
             return;
@@ -222,7 +242,7 @@ public class VisualSoundsPlugin extends Plugin {
         handleSoundEffect(soundEffectPlayed.getSoundId());
     }
 
-    @Subscribe
+	@Subscribe(priority = -3)
     public void onAreaSoundEffectPlayed(AreaSoundEffectPlayed areaSoundEffectPlayed) {
         if (!displayAreaEffects) {
             return;
@@ -250,18 +270,42 @@ public class VisualSoundsPlugin extends Plugin {
      */
     private void handleAmbientSoundEffect(AmbientSoundEffect ambientSoundEffect) {
         int[] backgroundSoundEffectIds = ambientSoundEffect.getBackgroundSoundEffectIds();
-        if (backgroundSoundEffectIds != null) {
+		GameSound gameSoundPrimary = getGameSound(ambientSoundEffect.getSoundEffectId());
+		if (gameSoundPrimary != null)
+		{
+			// doing a ambientSounds.containsKey didn't work so I did this.
+			if (ambientSounds.size() == 0)
+			{
+				ambientSounds.put(gameSoundPrimary, new GameSoundList(30, true));
+			}
+			else
+			{
+
+				boolean newAmbientSound = true;
+				for (GameSound gs: ambientSounds.keySet())
+				{
+					if (gs.equals(gameSoundPrimary))
+					{
+						newAmbientSound = false;
+						gameSoundPrimary = gs;
+					}
+				}
+				if (newAmbientSound)
+				{
+					ambientSounds.put(gameSoundPrimary, new GameSoundList(30, true));
+				}
+			}
+		}
+
+        if (backgroundSoundEffectIds != null && ambientSounds.containsKey(gameSoundPrimary)) {
             for (int backgroundSoundEffectId : backgroundSoundEffectIds) {
                 GameSound gameSound = getGameSound(backgroundSoundEffectId);
                 if (gameSound != null) {
-                    ambientSounds.add(gameSound);
-                }
+					GameSoundList ambientSoundList = ambientSounds.get(gameSoundPrimary);
+					ambientSoundList.add(gameSound);
+					ambientSounds.put(gameSoundPrimary, ambientSoundList);
+				}
             }
-        }
-
-        GameSound gameSound = getGameSound(ambientSoundEffect.getSoundEffectId());
-        if (gameSound != null) {
-            ambientSounds.add(gameSound);
         }
     }
 


### PR DESCRIPTION
Group the ambient sounds together under a header, left side is the primary, right side is the parts.

Add equals to GameSound so that only uniques are added to the ambient list

Don't handle ambients per game tick, handle it per map load as that's when they're loaded anyways.

<img width="674" height="563" alt="image" src="https://github.com/user-attachments/assets/11a020ec-977b-4393-aae2-86d4fab1eb80" />

In this picture the -1 primary contains all of the bank jingles and the pub sounds. 


I put them in priority -3 as that makes it run *after* annoyance mute would if users are trying to combine this plugin with the other to remove sounds. You can remove them if you'd like. 

Another example:
<img width="406" height="494" alt="image" src="https://github.com/user-attachments/assets/0b8c1aec-5d70-4cc2-8f7d-8ad82193180e" />


Closes #37 

